### PR TITLE
TIES Calculation efficiency improvement (#186)

### DIFF
--- a/mergekit/merge_methods/generalized_task_arithmetic.py
+++ b/mergekit/merge_methods/generalized_task_arithmetic.py
@@ -196,7 +196,7 @@ def get_mask(
     sign = delta.sign().to(mask_dtype)
 
     if method == "sum":
-        sign_weight = (sign * delta.abs()).sum(dim=0)
+        sign_weight = delta.sum(dim=0)
         majority_sign = (sign_weight >= 0).to(mask_dtype) * 2 - 1
         del sign_weight
     elif method == "count":


### PR DESCRIPTION
When calculating the sign weight, the code currently multiplies the delta's sign tensor by delta's absolute value.

This is the same as just using the original delta tensor - unless there's some specific edge case I'm missing.


![image](https://github.com/arcee-ai/mergekit/assets/8410140/05a1f967-681f-43e2-9c53-fb1d7301de84)

The two extra steps (the abs() and multiplication) add a fairly hefty time penalty, resulting in TIES being notably slower than the other merge methods:

![image](https://github.com/arcee-ai/mergekit/assets/8410140/6309e1a7-d883-4eb1-97e4-cf03faccc914)